### PR TITLE
fixed escaping problem on uploadRestriction config 

### DIFF
--- a/grails-app/views/ofm.gsp
+++ b/grails-app/views/ofm.gsp
@@ -54,7 +54,7 @@
                 },
                 security: {
                     uploadPolicy: "DISALLOW_ALL",
-                    uploadRestrictions: [${config.uploadRestrictions}]
+                    uploadRestrictions: [${raw(config.uploadRestrictions)}]
                 },
                 upload: {
                     overwrite: false,


### PR DESCRIPTION
when grails configiration was grails.views.default.codec = "html", the  uploadRestrictions: [${config.uploadRestrictions}] config is escaped and not showing up on the browser. patch is  "uploadRestrictions: [${raw(config.uploadRestrictions)}]"
