### PR TITLE
Issue 14

### DIFF
--- a/grails-app/controllers/org/gualdi/grails/plugins/ckeditor/OpenFileManagerConnectorController.groovy
+++ b/grails-app/controllers/org/gualdi/grails/plugins/ckeditor/OpenFileManagerConnectorController.groovy
@@ -27,10 +27,7 @@ class OpenFileManagerConnectorController {
 
     def messageSource
 
-    /**
-     * Entry point
-     *
-     */
+    /** Entry point */
     def index = {
         render view: "/ofm", model: [configUrl: getConfigUrl()]
     }
@@ -126,7 +123,7 @@ class OpenFileManagerConnectorController {
         def tmp
         def bUrl = PathUtils.getBaseUrl([space: params.space, type: params.type])
         if (config?.upload?.baseurl) {
-            if (config?.upload?.baseurl.startsWith("http")) {
+            if (config?.upload?.baseurl?.startsWith("http")) {
                 tmp = PathUtils.checkSlashes(config?.upload?.baseurl, "R-")
             }
             else {
@@ -198,16 +195,14 @@ class OpenFileManagerConnectorController {
         def baseUrl = PathUtils.getBaseUrl(params)
         def baseDir = getBaseDir(baseUrl)
 
-        if (log.isDebugEnabled()) {
-            log.debug "=============================================="
-            log.debug "FILEMANAGER"
-            log.debug "baseDir = ${baseDir}"
-            log.debug "baseUrl = ${baseUrl}"
-            log.debug "type = ${type}"
-            log.debug "space = ${space}"
-            log.debug "showThumbs = ${showThumbs}"
-            log.debug "=============================================="
-        }
+        log.debug "=============================================="
+        log.debug "FILEMANAGER"
+        log.debug "baseDir = ${baseDir}"
+        log.debug "baseUrl = ${baseUrl}"
+        log.debug "type = ${type}"
+        log.debug "space = ${space}"
+        log.debug "showThumbs = ${showThumbs}"
+        log.debug "=============================================="
 
         def resp
         switch (mode) {
@@ -262,16 +257,14 @@ class OpenFileManagerConnectorController {
         def baseUrl = PathUtils.getBaseUrl(params)
         def baseDir = getBaseDir(baseUrl)
 
-        if (log.isDebugEnabled()) {
-            log.debug "=============================================="
-            log.debug "QUICKUPLOAD"
-            log.debug "baseDir = ${baseDir}"
-            log.debug "baseUrl = ${baseUrl}"
-            log.debug "type = ${type}"
-            log.debug "space = ${space}"
-            log.debug "showThumbs = ${showThumbs}"
-            log.debug "=============================================="
-        }
+        log.debug "=============================================="
+        log.debug "QUICKUPLOAD"
+        log.debug "baseDir = ${baseDir}"
+        log.debug "baseUrl = ${baseUrl}"
+        log.debug "type = ${type}"
+        log.debug "space = ${space}"
+        log.debug "showThumbs = ${showThumbs}"
+        log.debug "=============================================="
 
         quickUpload(baseDir, baseUrl, "/", type, request)
 
@@ -357,7 +350,7 @@ class OpenFileManagerConnectorController {
                 if (showThumbs) {
                     def config = grailsApplication.config.ckeditor
                     if (config?.upload?.baseurl) {
-                        if (config?.upload?.baseurl.startsWith("http")) {
+                        if (config?.upload?.baseurl?.startsWith("http")) {
                             preview = PathUtils.checkSlashes(config?.upload?.baseurl, "R-") + baseUrl + path
                         }
                         else {

--- a/grails-app/taglib/org/gualdi/grails/plugins/ckeditor/CkeditorTagLib.groovy
+++ b/grails-app/taglib/org/gualdi/grails/plugins/ckeditor/CkeditorTagLib.groovy
@@ -16,12 +16,9 @@
 
 package org.gualdi.grails.plugins.ckeditor
 
-import grails.util.Environment
-
 /**
  * @author Stefano Gualdi <stefano.gualdi@gmail.com>
  */
-
 class CkeditorTagLib {
 
     static namespace = "ckeditor"
@@ -31,18 +28,18 @@ class CkeditorTagLib {
         out << editor.renderResources()
     }
 
-	def config = { attrs, body ->
+    def config = { attrs, body ->
         def cfg = new CkeditorConfig(request)
 
-		def var = attrs.remove('var');
+        def var = attrs.remove('var');
         try {
-			if (var) {
-				def value = body()
-	            cfg.addComplexConfigItem(var, value)
-			}
-			else {
-	            cfg.addConfigItem(attrs)
-			}
+            if (var) {
+                def value = body()
+                cfg.addComplexConfigItem(var, value)
+            }
+            else {
+                cfg.addConfigItem(attrs)
+            }
         }
         catch (Exception e) {
             throwTagError(e.message)
@@ -54,13 +51,13 @@ class CkeditorTagLib {
         out << editor.renderEditor()
     }
 
-	def fileBrowser = { attrs, body ->
-		def editor = new Ckeditor(request, attrs, body())
-		out << editor.renderFileBrowser()
+    def fileBrowser = { attrs, body ->
+        def editor = new Ckeditor(request, attrs, body())
+        out << editor.renderFileBrowser()
     }
 
     def fileBrowserLink = { attrs ->
-		def editor = new Ckeditor(request, attrs)
-		out << editor.renderFileBrowserLink()
+        def editor = new Ckeditor(request, attrs)
+        out << editor.renderFileBrowserLink()
     }
 }

--- a/src/groovy/org/gualdi/grails/plugins/ckeditor/Ckeditor.groovy
+++ b/src/groovy/org/gualdi/grails/plugins/ckeditor/Ckeditor.groovy
@@ -27,11 +27,11 @@ class Ckeditor {
     private final Logger log = Logger.getLogger(getClass())
 
     def config
-	def initialValue
+    def initialValue
 
     Ckeditor(request, attrs, value = "") {
-		this.config = new CkeditorConfig(request, attrs)
-		this.initialValue = value
+        this.config = new CkeditorConfig(request, attrs)
+        this.initialValue = value
     }
 
     def renderResources() {
@@ -45,9 +45,9 @@ class Ckeditor {
     def renderEditor() {
         StringBuffer outb = new StringBuffer()
 
-		if (!this.config.append) {
-        	outb << """<textarea id="${this.config.instanceId}" name="${this.config.instanceName}">${this.initialValue?.encodeAsHTML()}</textarea>\n"""
-		}
+        if (!this.config.append) {
+            outb << """<textarea id="${this.config.instanceId}" name="${this.config.instanceName}">${this.initialValue?.encodeAsHTML()}</textarea>\n"""
+        }
         outb << """<script type="text/javascript">\n"""
 
         if (this.config.removeInstance) {
@@ -55,14 +55,14 @@ class Ckeditor {
         }
 
         outb << """CKEDITOR."""
-		if (this.config.append) {
-			outb << """appendTo"""
-		}
-		else {
-			outb << """replace"""
-		}
-		outb << """('${this.config.instanceId}'"""
-		outb << this.config.configuration
+        if (this.config.append) {
+            outb << """appendTo"""
+        }
+        else {
+            outb << """replace"""
+        }
+        outb << """('${this.config.instanceId}'"""
+        outb << this.config.configuration
         outb << """);\n"""
         outb << """</script>\n"""
 
@@ -88,10 +88,10 @@ class Ckeditor {
         outb << this.initialValue.encodeAsHTML()
         outb << "</a>"
 
-		return outb.toString()
+        return outb.toString()
     }
 
     def renderFileBrowserLink() {
-		return this.config.getBrowseUrl(this.config.type, this.config.userSpace, this.config.fileBrowser, this.config.showThumbs, this.config.viewMode)
+        return this.config.getBrowseUrl(this.config.type, this.config.userSpace, this.config.fileBrowser, this.config.showThumbs, this.config.viewMode)
     }
 }

--- a/src/groovy/org/gualdi/grails/plugins/ckeditor/CkeditorConfig.groovy
+++ b/src/groovy/org/gualdi/grails/plugins/ckeditor/CkeditorConfig.groovy
@@ -26,30 +26,29 @@ import org.apache.commons.lang.WordUtils
 /**
  * @author Stefano Gualdi <stefano.gualdi@gmail.com>
  */
-
 class CkeditorConfig {
-	
-	private final Logger log = Logger.getLogger(getClass())
+
+    private final Logger log = Logger.getLogger(getClass())
 
     static final REQUEST_CONFIG = "ckeditor.plugin.config"
 
-	static final PLUGIN_NAME = "ckeditor"
+    static final PLUGIN_NAME = "ckeditor"
 
     static final DEFAULT_CONNECTORS_PREFIX = "ck"
 
-	static final DEFAULT_BASEDIR = "/uploads/"
+    static final DEFAULT_BASEDIR = "/uploads/"
 
-	static final DEFAULT_USERSPACE = ""
-    
-	static final DEFAULT_INSTANCENAME = "editor"
+    static final DEFAULT_USERSPACE = ""
 
-	static final DEFAULT_FILEBROWSER = "ofm" // ofm
+    static final DEFAULT_INSTANCENAME = "editor"
+
+    static final DEFAULT_FILEBROWSER = "ofm" // ofm
 
     static final DEFAULT_SHOWTHUMBS = false
 
     static final DEFAULT_VIEWMODE = "grid"
 
-	static final RESOURCE_TYPES = ['link', 'image', 'flash']
+    static final RESOURCE_TYPES = ['link', 'image', 'flash']
 
     static final OFM_IMAGE_EXTS = ['jpg', 'jpeg', 'gif', 'png']
 
@@ -65,79 +64,79 @@ class CkeditorConfig {
     def instanceId
     def instanceName
     def userSpace
-	def append
+    def append
 
     def fileBrowser
     def defaultFileBrowser
     def showThumbs
     def viewMode
 
-	def type
-	def target
+    def type
+    def target
 
     def removeInstance
 
-	def config
-	def localConfig
+    def config
+    def localConfig
 
     CkeditorConfig(request, attrs = null) {
         def cfg = Holders.config
 
-		this.contextPath = request.contextPath
-		this.basePath = PluginUtils.getPluginResourcePath(this.contextPath, this.PLUGIN_NAME)
+        this.contextPath = request.contextPath
+        this.basePath = PluginUtils.getPluginResourcePath(this.contextPath, PLUGIN_NAME)
 
         this.connectorsPrefix = getConnectorsPrefix()
 
-        this.defaultFileBrowser = cfg.ckeditor?.defaultFileBrowser ?: this.DEFAULT_FILEBROWSER
+        this.defaultFileBrowser = cfg.ckeditor?.defaultFileBrowser ?: DEFAULT_FILEBROWSER
 
         this.skipAllowedItemsCheck = cfg.ckeditor?.skipAllowedItemsCheck ?: false
 
-		this.localConfig = [:]
-		
-		createOrRetrieveConfig(request)
-		
-		if (attrs) {
-	        this.instanceName = attrs.remove("name") ?: this.DEFAULT_INSTANCENAME
+        this.localConfig = [:]
+
+        createOrRetrieveConfig(request)
+
+        if (attrs) {
+            this.instanceName = attrs.remove("name") ?: DEFAULT_INSTANCENAME
             this.instanceId = attrs.remove("id") ?: this.instanceName
-			this.userSpace = attrs.remove("userSpace") ?: this.DEFAULT_USERSPACE
-			this.append = (attrs.remove("append") == "true")
+            this.userSpace = attrs.remove("userSpace") ?: DEFAULT_USERSPACE
+            this.append = (attrs.remove("append") == "true")
 
             this.fileBrowser = attrs.remove("fileBrowser") ?: this.defaultFileBrowser
             this.showThumbs = (attrs.remove("showThumbs") == "true")
-            this.viewMode = attrs.remove("viewMode") ?: this.DEFAULT_VIEWMODE
+            this.viewMode = attrs.remove("viewMode") ?: DEFAULT_VIEWMODE
 
-			this.type = attrs.remove("type")
-			this.target = attrs.remove("target")
+            this.type = attrs.remove("type")
+            this.target = attrs.remove("target")
 
             this.removeInstance = (attrs.remove("removeInstance") == "true")
 
-			addConfigItem(attrs, true)			
-		}
+            addConfigItem(attrs, true)
+        }
     }
 
-	private createOrRetrieveConfig(request) {
+    private createOrRetrieveConfig(request) {
         if (!request[REQUEST_CONFIG]) {
             request[REQUEST_CONFIG] = [:]
         }
         this.config = request[REQUEST_CONFIG]
-	}
+    }
 
     def addConfigItem(attrs, local = false) {
         attrs?.each { key, value ->
             if (this.skipAllowedItemsCheck || key in ALLOWED_CONFIG_ITEMS || key.startsWith('filebrowser')) {
-				def tmp = value?.trim()
-				if (!tmp?.isNumber() && 
-					!tmp?.equalsIgnoreCase('true') && 
-					!tmp?.equalsIgnoreCase('false') && 
-					!tmp?.startsWith('CKEDITOR.')) {
-					tmp = "'${tmp}'"
-				}
-				if (local) {
-					this.localConfig[key] = tmp
-				}
-				else {
-                	this.config[key] = tmp
-				}
+                def tmp = value?.trim()
+                if (!tmp?.isNumber() &&
+                        !tmp?.equalsIgnoreCase('true') &&
+                        !tmp?.equalsIgnoreCase('false') &&
+                        !tmp?.startsWith('CKEDITOR.')) {
+                    tmp = "'${tmp}'"
+                }
+                if (local) {
+                    this.localConfig[key] = tmp
+                }
+                else {
+                    this.config[key] = tmp
+                }
             }
             else {
                 throw new UnknownOptionException("Unknown option: ${key}. Option names are case sensitive! Check the spelling.")
@@ -145,67 +144,67 @@ class CkeditorConfig {
         }
     }
 
-	def addComplexConfigItem(var, value) {
+    def addComplexConfigItem(var, value) {
         if (this.skipAllowedItemsCheck || var in ALLOWED_CONFIG_ITEMS || var.startsWith('toolbar_')) {
-			this.config[var] = value
-		}
-		else {
-		    throw new UnknownOptionException("Unknown option: ${var}. Option names are case sensitive! Check the spelling.")
+            this.config[var] = value
+        }
+        else {
+            throw new UnknownOptionException("Unknown option: ${var}. Option names are case sensitive! Check the spelling.")
         }
     }
 
-	def getBrowseUrl(type, userSpace, fileBrowser, showThumbs, viewMode) {
+    def getBrowseUrl(type, userSpace, fileBrowser, showThumbs, viewMode) {
         def browserUrl
         def prefix = getConnectorsPrefix()
-        browserUrl = "${this.contextPath}/${prefix}/ofm?fileConnector=${this.contextPath}/${prefix}/ofm/filemanager&type=${type}${userSpace ? '&space='+ userSpace : ''}${showThumbs ? '&showThumbs='+ showThumbs : ''}${'&viewMode='+ viewMode}"
+        browserUrl = "${this.contextPath}/${prefix}/ofm?fileConnector=${this.contextPath}/${prefix}/ofm/filemanager&type=${type}${userSpace ? '&space=' + userSpace : ''}${showThumbs ? '&showThumbs=' + showThumbs : ''}${'&viewMode=' + viewMode}"
 
         return browserUrl
-	}
-	
-	def getUploadUrl(type, userSpace) {
-        return "${this.contextPath}/${getConnectorsPrefix()}/uploader?type=${type}${userSpace ? '&space='+ userSpace : ''}"
-	}
+    }
+
+    def getUploadUrl(type, userSpace) {
+        return "${this.contextPath}/${getConnectorsPrefix()}/uploader?type=${type}${userSpace ? '&space=' + userSpace : ''}"
+    }
 
     def getConfiguration() {
-		def ckconfig = Holders.config.ckeditor
+        def ckconfig = Holders.config.ckeditor
 
-		def customConfig = ckconfig?.config 
-		if (customConfig && !this.config["customConfig"]) {
-			customConfig = PathUtils.checkSlashes(customConfig, "L- R-", true)
-			this.config["customConfig"] = "'${this.contextPath}/${customConfig}'"	
-		}
+        def customConfig = ckconfig?.config
+        if (customConfig && !this.config["customConfig"]) {
+            customConfig = PathUtils.checkSlashes(customConfig, "L- R-", true)
+            this.config["customConfig"] = "'${this.contextPath}/${customConfig}'"
+        }
 
-		// Collect browser settings per media type
+        // Collect browser settings per media type
         this.resourceTypes.each { t ->
             def type = WordUtils.capitalize(t)
-			def typeForConnector = "${type == 'Link' ? 'File' : type}"
-			
+            def typeForConnector = "${type == 'Link' ? 'File' : type}"
+
             if (ckconfig?.upload?."${t}"?.browser) {
-				this.config["filebrowser${type}BrowseUrl"] = "'${getBrowseUrl(typeForConnector, this.userSpace, this.fileBrowser, this.showThumbs, this.viewMode)}'"
+                this.config["filebrowser${type}BrowseUrl"] = "'${getBrowseUrl(typeForConnector, this.userSpace, this.fileBrowser, this.showThumbs, this.viewMode)}'"
             }
             if (ckconfig?.upload?."${t}"?.upload) {
-				this.config["filebrowser${type}UploadUrl"] = "'${getUploadUrl(typeForConnector, this.userSpace)}'" 
+                this.config["filebrowser${type}UploadUrl"] = "'${getUploadUrl(typeForConnector, this.userSpace)}'"
             }
         }
 
-		// Config options
-		def configs = []
-		this.config.each {k, v ->
-			if (!localConfig[k]) {
-				configs << "${k}: ${v}"
-			}
-		}
-		this.localConfig.each {k, v ->
-			configs << "${k}: ${v}"
-		}
+        // Config options
+        def configs = []
+        this.config.each { k, v ->
+            if (!localConfig[k]) {
+                configs << "${k}: ${v}"
+            }
+        }
+        this.localConfig.each { k, v ->
+            configs << "${k}: ${v}"
+        }
 
-		StringBuffer configuration = new StringBuffer()
+        StringBuffer configuration = new StringBuffer()
         if (configs.size()) {
             configuration << """, {\n"""
-           	configuration << configs.join(",\n")
+            configuration << configs.join(",\n")
             configuration << """}\n"""
         }
-	
+
         return configuration
     }
 
@@ -229,235 +228,235 @@ class CkeditorConfig {
 
     // See: http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html
     static final ALLOWED_CONFIG_ITEMS = [
-        // Items not listed in main config file
-        'uiColor',
-        'readOnly',
+            // Items not listed in main config file
+            'uiColor',
+            'readOnly',
 
-		// Main config
-		'customConfig',
-		'autoUpdateElement',
-		'baseFloatZIndex',
-		'baseHref',
-		'contentsCss',
-		'contentsLangDirection',
-		'contentsLanguage',
-		'language',
-		'defaultLanguage',
-		'enterMode',
-		'forceEnterMode',
-		'shiftEnterMode',
-		'corePlugins',
-		'docType',
-		'bodyId',
-		'bodyClass',
-		'fullPage',
-		'height',
-		'plugins',
-		'extraPlugins',
-		'removePlugins',
-		'protectedSource',
-		'tabIndex',
-		'theme',
-		'skin',
-		'width',
-		'baseFloatZIndex',
+            // Main config
+            'customConfig',
+            'autoUpdateElement',
+            'baseFloatZIndex',
+            'baseHref',
+            'contentsCss',
+            'contentsLangDirection',
+            'contentsLanguage',
+            'language',
+            'defaultLanguage',
+            'enterMode',
+            'forceEnterMode',
+            'shiftEnterMode',
+            'corePlugins',
+            'docType',
+            'bodyId',
+            'bodyClass',
+            'fullPage',
+            'height',
+            'plugins',
+            'extraPlugins',
+            'removePlugins',
+            'protectedSource',
+            'tabIndex',
+            'theme',
+            'skin',
+            'width',
+            'baseFloatZIndex',
 
-        // plugins/autogrow/plugin.js
-        'autoGrow_minHeight',
-        'autoGrow_maxHeight',
-        'autoGrow_onStartup',
-        'autoGrow_bottomSpace',
+            // plugins/autogrow/plugin.js
+            'autoGrow_minHeight',
+            'autoGrow_maxHeight',
+            'autoGrow_onStartup',
+            'autoGrow_bottomSpace',
 
-        // plugins/basicstyles/plugin.js
-        'coreStyles_bold',
-        'coreStyles_italic',
-        'coreStyles_underline',
-        'coreStyles_strike',
-        'coreStyles_subscript',
-        'coreStyles_superscript',
+            // plugins/basicstyles/plugin.js
+            'coreStyles_bold',
+            'coreStyles_italic',
+            'coreStyles_underline',
+            'coreStyles_strike',
+            'coreStyles_subscript',
+            'coreStyles_superscript',
 
-        // plugins/colorbutton/plugin.js
-        'colorButton_enableMore',
-        'colorButton_colors',
-        'colorButton_foreStyle',
-        'colorButton_backStyle',
+            // plugins/colorbutton/plugin.js
+            'colorButton_enableMore',
+            'colorButton_colors',
+            'colorButton_foreStyle',
+            'colorButton_backStyle',
 
-        // plugins/contextmenu/plugin.js
-        'browserContextMenuOnCtrl',
+            // plugins/contextmenu/plugin.js
+            'browserContextMenuOnCtrl',
 
-        // plugins/devtools/plugin.js
-        'devtools_textCallback',
-        'devtools_styles',
+            // plugins/devtools/plugin.js
+            'devtools_textCallback',
+            'devtools_styles',
 
-        // plugins/dialog/plugin.js
-        'dialog_backgroundCoverColor',
-        'dialog_backgroundCoverOpacity',
-        'dialog_startupFocusTab',
-        'dialog_magnetDistance',
-        'dialog_buttonsOrder',
-        'removeDialogTabs',
+            // plugins/dialog/plugin.js
+            'dialog_backgroundCoverColor',
+            'dialog_backgroundCoverOpacity',
+            'dialog_startupFocusTab',
+            'dialog_magnetDistance',
+            'dialog_buttonsOrder',
+            'removeDialogTabs',
 
-        // plugins/editingblock/plugin.js
-        'startupMode',
-        'startupFocus',
-        'editingBlock',
+            // plugins/editingblock/plugin.js
+            'startupMode',
+            'startupFocus',
+            'editingBlock',
 
-        // plugins/entities/plugin.js
-        'basicEntities',
-        'entities',
-        'entities_latin',
-        'entities_greek',
-        'entities_processNumerical',
-        'entities_additional',
+            // plugins/entities/plugin.js
+            'basicEntities',
+            'entities',
+            'entities_latin',
+            'entities_greek',
+            'entities_processNumerical',
+            'entities_additional',
 
-        // plugins/filebrowser/plugin.js
-        'filebrowserBrowseUrl',
-        'filebrowserUploadUrl',
-        'filebrowserImageBrowseUrl',
-        'filebrowserFlashBrowseUrl',
-        'filebrowserImageUploadUrl',
-        'filebrowserFlashUploadUrl',
-        'filebrowserImageBrowseLinkUrl',
-        'filebrowserWindowFeatures',
-        'filebrowserWindowWidth',
-        'filebrowserWindowHeight',
+            // plugins/filebrowser/plugin.js
+            'filebrowserBrowseUrl',
+            'filebrowserUploadUrl',
+            'filebrowserImageBrowseUrl',
+            'filebrowserFlashBrowseUrl',
+            'filebrowserImageUploadUrl',
+            'filebrowserFlashUploadUrl',
+            'filebrowserImageBrowseLinkUrl',
+            'filebrowserWindowFeatures',
+            'filebrowserWindowWidth',
+            'filebrowserWindowHeight',
 
-        // plugins/find/plugin.js
-        'find_highlight',
+            // plugins/find/plugin.js
+            'find_highlight',
 
-        // plugins/font/plugin.js
-        'font_names',
-        'font_defaultLabel',
-        'font_style',
-        'fontSize_sizes',
-        'fontSize_defaultLabel',
-        'fontSize_style',
+            // plugins/font/plugin.js
+            'font_names',
+            'font_defaultLabel',
+            'font_style',
+            'fontSize_sizes',
+            'fontSize_defaultLabel',
+            'fontSize_style',
 
-        // plugins/format/plugin.js
-        'format_tags',
-        'format_p',
-        'format_div',
-        'format_pre',
-        'format_address',
-        'format_h1',
-        'format_h2',
-        'format_h3',
-        'format_h4',
-        'format_h5',
-        'format_h6',
+            // plugins/format/plugin.js
+            'format_tags',
+            'format_p',
+            'format_div',
+            'format_pre',
+            'format_address',
+            'format_h1',
+            'format_h2',
+            'format_h3',
+            'format_h4',
+            'format_h5',
+            'format_h6',
 
-        // plugins/htmldataprocessor/plugin.js
-        'forceSimpleAmpersand',
-        'fillEmptyBlocks',
+            // plugins/htmldataprocessor/plugin.js
+            'forceSimpleAmpersand',
+            'fillEmptyBlocks',
 
-        // plugins/image/plugin.js
-        'image_removeLinkByEmptyURL',
-        'image_previewText',
+            // plugins/image/plugin.js
+            'image_removeLinkByEmptyURL',
+            'image_previewText',
 
-        // plugins/indent/plugin.js
-        'indentOffset',
-        'indentUnit',
-        'indentClasses',
+            // plugins/indent/plugin.js
+            'indentOffset',
+            'indentUnit',
+            'indentClasses',
 
-        // plugins/justify/plugin.js
-        'justifyClasses',
+            // plugins/justify/plugin.js
+            'justifyClasses',
 
-        // plugins/keystrokes/plugin.js
-        'blockedKeystrokes',
-        'keystrokes',
+            // plugins/keystrokes/plugin.js
+            'blockedKeystrokes',
+            'keystrokes',
 
-        // plugins/menu/plugin.js
-        'menu_subMenuDelay',
-        'menu_groups',
+            // plugins/menu/plugin.js
+            'menu_subMenuDelay',
+            'menu_groups',
 
-        // plugins/newpage/plugin.js
-        'newpage_html',
+            // plugins/newpage/plugin.js
+            'newpage_html',
 
-        // plugins/pastefromword/plugin.js
-        'pasteFromWordPromptCleanup',
-        'pasteFromWordCleanupFile',
+            // plugins/pastefromword/plugin.js
+            'pasteFromWordPromptCleanup',
+            'pasteFromWordCleanupFile',
 
-        // plugins/pastetext/plugin.js
-        'forcePasteAsPlainText',
+            // plugins/pastetext/plugin.js
+            'forcePasteAsPlainText',
 
-        // plugins/removeformat/plugin.js
-        'removeFormatTags',
-        'removeFormatAttributes',
+            // plugins/removeformat/plugin.js
+            'removeFormatTags',
+            'removeFormatAttributes',
 
-        // plugins/resize/plugin.js
-        'resize_minWidth',
-        'resize_minHeight',
-        'resize_maxWidth',
-        'resize_maxHeight',
-        'resize_enabled',
-        'resize_dir',
+            // plugins/resize/plugin.js
+            'resize_minWidth',
+            'resize_minHeight',
+            'resize_maxWidth',
+            'resize_maxHeight',
+            'resize_enabled',
+            'resize_dir',
 
-        // plugins/scayt/plugin.js
-        'scayt_autoStartup',
-        'scayt_maxSuggestions',
-        'scayt_customerid',
-        'scayt_moreSuggestions',
-        'scayt_contextCommands',
-        'scayt_sLang',
-        'scayt_uiTabs',
-        'scayt_srcUrl',
-        'scayt_customDictionaryIds',
-        'scayt_userDictionaryName',
-        'scayt_contextMenuItemsOrder',
+            // plugins/scayt/plugin.js
+            'scayt_autoStartup',
+            'scayt_maxSuggestions',
+            'scayt_customerid',
+            'scayt_moreSuggestions',
+            'scayt_contextCommands',
+            'scayt_sLang',
+            'scayt_uiTabs',
+            'scayt_srcUrl',
+            'scayt_customDictionaryIds',
+            'scayt_userDictionaryName',
+            'scayt_contextMenuItemsOrder',
 
-        // plugins/showblocks/plugin.js
-        'startupOutlineBlocks',
+            // plugins/showblocks/plugin.js
+            'startupOutlineBlocks',
 
-        // plugins/showborders/plugin.js
-        'startupShowBorders',
+            // plugins/showborders/plugin.js
+            'startupShowBorders',
 
-        // plugins/smiley/plugin.js
-        'smiley_path',
-        'smiley_images',
-        'smiley_descriptions',
-        'smiley_columns',
+            // plugins/smiley/plugin.js
+            'smiley_path',
+            'smiley_images',
+            'smiley_descriptions',
+            'smiley_columns',
 
-        // plugins/specialchar/plugin.js
-        'specialChars',
+            // plugins/specialchar/plugin.js
+            'specialChars',
 
-        // plugins/styles/plugin.js
-        'disableReadonlyStyling',
-        'stylesSet',
+            // plugins/styles/plugin.js
+            'disableReadonlyStyling',
+            'stylesSet',
 
-        // plugins/stylesheetparser/plugin.js
-        'stylesheetParser_skipSelectors',
-        'stylesheetParser_validSelectors',
+            // plugins/stylesheetparser/plugin.js
+            'stylesheetParser_skipSelectors',
+            'stylesheetParser_validSelectors',
 
-        // plugins/tab/plugin.js
-        'tabSpaces',
-        'enableTabKeyTools',
+            // plugins/tab/plugin.js
+            'tabSpaces',
+            'enableTabKeyTools',
 
-        // plugins/templates/plugin.js
-        'templates',
-        'templates_files',
-        'templates_replaceContent',
+            // plugins/templates/plugin.js
+            'templates',
+            'templates_files',
+            'templates_replaceContent',
 
-        // plugins/toolbar/plugin.js
-        'toolbarLocation',
-        'toolbar',
-        'toolbar_Basic',
-        'toolbar_Full',
-        'toolbarCanCollapse',
-        'toolbarStartupExpanded',
-        'toolbarGroupCycling',
+            // plugins/toolbar/plugin.js
+            'toolbarLocation',
+            'toolbar',
+            'toolbar_Basic',
+            'toolbar_Full',
+            'toolbarCanCollapse',
+            'toolbarStartupExpanded',
+            'toolbarGroupCycling',
 
-        // plugins/undo/plugin.js
-        'undoStackSize',
+            // plugins/undo/plugin.js
+            'undoStackSize',
 
-        // plugins/wsc/plugin.js
-        'wsc_customerId',
-        'wsc_customLoaderScript',
+            // plugins/wsc/plugin.js
+            'wsc_customerId',
+            'wsc_customLoaderScript',
 
-        // plugins/wysiwygarea/plugin.js
-        'disableObjectResizing',
-        'disableNativeTableHandles',
-        'disableNativeSpellChecker',
-        'ignoreEmptyParagraph',
-        'autoParagraph'
+            // plugins/wysiwygarea/plugin.js
+            'disableObjectResizing',
+            'disableNativeTableHandles',
+            'disableNativeSpellChecker',
+            'ignoreEmptyParagraph',
+            'autoParagraph'
     ]
 }

--- a/src/groovy/org/gualdi/grails/plugins/ckeditor/utils/FileUtils.groovy
+++ b/src/groovy/org/gualdi/grails/plugins/ckeditor/utils/FileUtils.groovy
@@ -30,15 +30,15 @@ class FileUtils {
     static isAllowed(ext, type) {
         def config = Holders.config.ckeditor.upload
 
-		def resourceType = type.toLowerCase()
+        def resourceType = type.toLowerCase()
         if (resourceType == 'file') {
             resourceType = 'link'
         }
-		def fileExt = ext.toLowerCase()
+        def fileExt = ext.toLowerCase()
 
-		def allowed = config."${resourceType}".allowed ?: []
-		def denied = config."${resourceType}".denied ?: []
+        def allowed = config."${resourceType}".allowed ?: []
+        def denied = config."${resourceType}".denied ?: []
 
-		return ((fileExt in allowed || allowed.empty ) && !(fileExt in denied))
+        return ((fileExt in allowed || allowed.empty) && !(fileExt in denied))
     }
 }

--- a/src/groovy/org/gualdi/grails/plugins/ckeditor/utils/PathUtils.groovy
+++ b/src/groovy/org/gualdi/grails/plugins/ckeditor/utils/PathUtils.groovy
@@ -53,20 +53,20 @@ class PathUtils {
     }
 
     static splitFilename(fileName) {
-    	def idx = fileName.lastIndexOf(".")
+        def idx = fileName.lastIndexOf(".")
         def name = fileName
         def ext = ""
         if (idx > 0) {
             name = fileName[0..idx - 1]
-            if(fileName.length() > idx + 1) { 
-        		ext = fileName[idx + 1..-1]
-	        }
+            if (fileName.length() > idx + 1) {
+                ext = fileName[idx + 1..-1]
+            }
         }
         return [name: name, ext: ext]
     }
 
     static getFilePath(fileName) {
-    	def idx = fileName.lastIndexOf(File.separator)
+        def idx = fileName.lastIndexOf(File.separator)
         def path = fileName[0..idx]
 
         return path
@@ -75,7 +75,7 @@ class PathUtils {
     static sanitizePath(path) {
         def result = ""
         if (path) {
-	        // remove: . \ / | : ? * " ' ` ~ < > {space}
+            // remove: . \ / | : ? * " ' ` ~ < > {space}
             result = path.replaceAll(/\.|\/|\\|\||:|\?|\*|"|'|~|`|<|>| /, "")
         }
         return result
@@ -101,13 +101,13 @@ class PathUtils {
                 if (isAdd) {
                     if (r[0].toUpperCase() == 'L') {
                         // Add separator on left
-                        if (!result.startsWith('/') && !result.startsWith('\\')  ) {
+                        if (!result.startsWith('/') && !result.startsWith('\\')) {
                             result = separator + result
                         }
                     }
                     else {
                         // Add separator on right
-                        if (!result.endsWith('/') && !result.endsWith('\\')  ) {
+                        if (!result.endsWith('/') && !result.endsWith('\\')) {
                             result = result + separator
                         }
                     }
@@ -115,13 +115,13 @@ class PathUtils {
                 else {
                     if (r[0].toUpperCase() == 'L') {
                         // Remove separator on left
-                        if (result.startsWith('/') || result.startsWith('\\')  ) {
+                        if (result.startsWith('/') || result.startsWith('\\')) {
                             result = result.substring(1)
                         }
                     }
                     else {
                         // Remove separator on right
-                        if (result.endsWith('/') || result.endsWith('\\')  ) {
+                        if (result.endsWith('/') || result.endsWith('\\')) {
                             result = result[0..-2]
                         }
                     }
@@ -134,7 +134,7 @@ class PathUtils {
     static normalizePath(path) {
         def el = path.tokenize(File.separator)
         def p = []
-        for(e in el) {
+        for (e in el) {
             if (e == ".") {
                 // skip
             }

--- a/src/groovy/org/gualdi/grails/plugins/ckeditor/utils/PluginUtils.groovy
+++ b/src/groovy/org/gualdi/grails/plugins/ckeditor/utils/PluginUtils.groovy
@@ -24,8 +24,8 @@ import grails.util.Holders
 
 class PluginUtils {
 
-	static getPluginResourcePath(contextPath, pluginName) {
+    static getPluginResourcePath(contextPath, pluginName) {
         String pluginVersion = Holders.pluginManager.getGrailsPlugin(pluginName)?.version
         return "${contextPath}/plugins/${pluginName.toLowerCase()}-$pluginVersion"
-	}
+    }
 }


### PR DESCRIPTION
1. A lot of tabs `\t` in source code instead of spaces
2. [OpenFileManagerConnectorController:129](https://github.com/stefanogualdi/grails-ckeditor/blob/master/grails-app/controllers/org/gualdi/grails/plugins/ckeditor/OpenFileManagerConnectorController.groovy#L129)

The line:
```groovy
            if (config?.upload?.baseurl.startsWith("http")) {
```
may cause NPE. Mayebe it wiuld be better to add safe navigation before `startsWith()` i.e.:
```groovy
            if (config?.upload?.baseurl?.startsWith("http")) {
```

3. In the [OpenFileManagerConnectorController:201](https://github.com/stefanogualdi/grails-ckeditor/blob/master/grails-app/controllers/org/gualdi/grails/plugins/ckeditor/OpenFileManagerConnectorController.groovy#L201)
```groovy
        if (log.isDebugEnabled()) {
            log.debug "=============================================="
            log.debug "FILEMANAGER"
            log.debug "baseDir = ${baseDir}"
            log.debug "baseUrl = ${baseUrl}"
            log.debug "type = ${type}"
            log.debug "space = ${space}"
            log.debug "showThumbs = ${showThumbs}"
            log.debug "=============================================="
        }
```
The check `log.isDebugEnabled()` is not needed because loger itself check it