### PR TITLE
Uses Compatible PluginManger

### DIFF
--- a/src/groovy/org/gualdi/grails/plugins/ckeditor/utils/PluginUtils.groovy
+++ b/src/groovy/org/gualdi/grails/plugins/ckeditor/utils/PluginUtils.groovy
@@ -17,6 +17,7 @@
 package org.gualdi.grails.plugins.ckeditor.utils
 
 import grails.util.Holders
+import org.codehaus.groovy.grails.plugins.GrailsPlugin
 
 /**
  * @author Stefano Gualdi <stefano.gualdi@gmail.com>
@@ -25,7 +26,14 @@ import grails.util.Holders
 class PluginUtils {
 
     static getPluginResourcePath(contextPath, pluginName) {
-        String pluginVersion = Holders.pluginManager.getGrailsPlugin(pluginName)?.version
+        GrailsPlugin plugin;
+        if (Holders.pluginManager != null) {
+            plugin = Holders.pluginManager.getGrailsPlugin((String)pluginName)
+        } else {
+            plugin = Holders.applicationContext.getBean('pluginManager').getGrailsPlugin((String)pluginName)
+        }
+
+        String pluginVersion = plugin.version;
         return "${contextPath}/plugins/${pluginName.toLowerCase()}-$pluginVersion"
     }
 }


### PR DESCRIPTION
Fixes Issue #13

- Instead of only attempting to get PluginManager from Holders if plugManager is null, use applicationContext to obtain bean instance.

This attempts to address issues with Grails versions prior to 2.4.*