### PR TITLE
remove URL mappings

### DIFF
--- a/grails-app/controllers/grails/plugins/ckeditor/UrlMappings.groovy
+++ b/grails-app/controllers/grails/plugins/ckeditor/UrlMappings.groovy
@@ -19,14 +19,5 @@ package grails.plugins.ckeditor
 class UrlMappings {
 
     static mappings = {
-        "/$controller/$action?/$id?(.$format)?"{
-            constraints {
-                // apply constraints here
-            }
-        }
-
-        "/"(view:"/index")
-        "500"(view:'/error')
-        "404"(view:'/notFound')
     }
 }


### PR DESCRIPTION
by leaving in the URL mappings in the plugin project, these mappings are subsequently added to projects that use the CKEditor plugin. Unfortunately in the current version of Grails, URL Mappings in the target project can't override mappings defined in the plugin.