### PR TITLE
Update documentation link

### DIFF
--- a/src/docs/tags/config.adoc
+++ b/src/docs/tags/config.adoc
@@ -9,7 +9,7 @@ All the configuration options defined with this tag will be used in every editor
 
 Option names are case sensitive and must be written as indicated in the official documentation.
 
-For a full reference of the available options please refer to the http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html[official documentation]
+For a full reference of the available options please refer to the http://docs.ckeditor.com/#!/api/CKEDITOR.config[official documentation]
 
 ==== Simple option
 


### PR DESCRIPTION
The documentation link was going to the config options for ckeditor 3. Now it points to the correct documentation.